### PR TITLE
fix(htmlSafe): handle htmlSafe case from error message

### DIFF
--- a/addon/validators/validator.js
+++ b/addon/validators/validator.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Messages from 'ember-validator/messages';
 import Errors from 'ember-validator/errors';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const {
   Object: EmberObject,
@@ -56,6 +57,11 @@ export default EmberObject.extend({
 
   render(message, options) {
     message = message || 'Invalid';
+
+    // Handle the `Ember.Handlebars.SafeString()` and the `Ember.String.htmlSafe()` cases.
+    if (isHTMLSafe(message)) {
+      message = message.toString();
+    }
 
     for(let option in options) {
       message = message.replace('{{' + option + '}}', options[option]);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-getowner-polyfill": "^1.0.0",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
@anandts88 We currently have an issue using [ember-i18n](https://github.com/jamesarosen/ember-i18n) because, by default, all of it's strings are [`Ember.String.htmlSafe()`](http://emberjs.com/api/classes/Ember.String.html#method_htmlSafe) strings and we don't account for this case in ember-validator.

I haven't had a chance to verify for all cases, As I know you're much more familiar with this addon than I am, please verify this PR and let me know if this fixes the scenario in all cases. If so then we need a new release. If not, or there is an issue with this commit, please let me know and lets work together to get the correct fix in the correct place(s). This will allow us to move forward with using `ember-i18n` as a content bearer for error strings along with `ember-validator`

Example of one issue today:

``` js
    var obj = Ember.Object.create({
      userName: null,
      password: null
    });

    let validations = {
      userName: {
        required: {
          message: get(this, 'i18n').t('errors.userName_error') // NOTE: This is an `htmlSafe` string
        }
      },

      password: {
        required: {
          message: get(this, 'i18n').t('errors.password_error') // NOTE: This is an `htmlSafe` string
        }
      }
    };

    this.validateMap({model: obj, validations});
```

/cc @jbailey4 @crodriguez1a
