### PR TITLE
allows addon to be nested and updates ember-cli version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.npmignore
+++ b/.npmignore
@@ -13,4 +13,4 @@
 .travis.yml
 bower.json
 ember-cli-build.js
-testem.json
+testem.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,23 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=1.10.1
-  - EMBER_TRY_SCENARIO=1.11.3
-  - EMBER_TRY_SCENARIO=1.12.1
-  - EMBER_TRY_SCENARIO=1.13.11
-  - EMBER_TRY_SCENARIO=2.0.2
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
@@ -26,14 +25,16 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-validator",
   "dependencies": {
-    "ember": "~2.3.1",
+    "ember": "~2.10.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,48 +2,34 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: '1.10.1',
+      name: 'ember-lts-2.4',
       bower: {
         dependencies: {
-          'ember': '1.10.1'
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: '1.11.3',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '1.10.1'
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
         }
-      }
-    },
-    {
-      name: '1.12.1',
-      bower: {
-        dependencies: {
-          'ember': '1.12.1'
-        }
-      }
-    },
-    {
-      name: '1.13.11',
-      bower: {
-        dependencies: {
-          'ember': '1.13.11'
-        }
-      }
-    },
-    {
-      name: '2.0.2',
-      bower: {
-        dependencies: {
-          'ember': '2.0.2'
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -56,6 +42,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -66,6 +57,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -78,6 +74,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -10,28 +10,22 @@ module.exports = {
   },
 
   included: function(app, parentAddon) {
-    var _app = app;
+    // https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-88122543
+    this._super.included.apply(this, arguments);
+
     var _options;
     var _useDateValidator;
 
-    // Quick fix for add-on nesting
-    // https://github.com/ember-cli/ember-cli/issues/3718
-    // https://github.com/aexmachina/ember-cli-sass/blob/v5.3.0/index.js#L73-L75
-    if (typeof app.import !== 'function' && app.app) {
-      _app = app.app;
+    var target = parentAddon || app;
+
+    // allow addon to be nested - see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (target.app) {
+      target = target.app;
     }
 
-    // https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-88122543
-    this._super.included.call(this, _app);
+    target.options = target.options || {};
 
-    // Per the ember-cli documentation
-    // http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
-    _app = (parentAddon || _app || {});
-
-    _app.options = _app.options || {};
-    _options = _app.options.emberValidator || {
-      useDateValidator: true
-    };
+    _options = target.options.emberValidator || { useDateValidator: true };
 
     _useDateValidator = _options.useDateValidator;
 
@@ -41,8 +35,8 @@ module.exports = {
 
     // Import moment library only when `useDateValidator` is set to true. By default moment library is imported.
     // If you dont want to use date validator then set `useDateValidator` to false.
-    if (_app.import && _useDateValidator) {
-      this.importBowerDependencies(_app);
+    if (target.import && _useDateValidator) {
+      this.importBowerDependencies(target);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
   "repository": {
     "type": "git",
@@ -24,26 +24,26 @@
   },
   "homepage": "https://github.com/anandts88/ember-validator#readme",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.2.0",
-    "ember-ajax": "0.7.1",
-    "ember-cli": "2.4.1",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
-    "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^2.0.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "^2.11.1",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "^0.2.9",
+    "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.3.0",
+    "ember-data": "^2.11.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4",
-    "ember-load-initializers": "^0.5.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.0",
-    "loader.js": "^4.0.0"
+    "loader.js": "^4.0.10"
   },
   "keywords": [
     "ember-addon",
@@ -64,7 +64,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-getowner-polyfill": "^1.0.0",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1"
+    "ember-string-ishtmlsafe-polyfill": "1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,12 +4,16 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 
@@ -29,7 +33,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      destroyApp(this.application);
-
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
The `app` argument in the `included` hook varies based on whether the addon is being used by another addon/engine (nested) or being consumed by an application. This PR attempts to solve all the scenarios in lieu of a better, public api.

See https://github.com/ember-cli/ember-cli/issues/3718

Also, updates ember-cli version.