### PR TITLE
Update isHTMLSafe polyfill dep

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -3,7 +3,6 @@ import Errors from 'ember-validator/errors';
 import Validator from 'ember-validator/validators/validator';
 import Constants from 'ember-validator/constants';
 import getOwner from 'ember-getowner-polyfill';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const {
   Mixin,
@@ -403,7 +402,7 @@ export default Mixin.create({
 
         if (typeof(options) === 'string') { // If error message is directly defined for the validator, the create options object with message.
           options = { message: options };
-        } else if (isHTMLSafe(options)) {
+        } else if (Ember.String.isHTMLSafe(options)) {
           options = { message: options.toString() };
         } else if (typeof(options) !== 'object') {
           options = {};

--- a/addon/validators/validator.js
+++ b/addon/validators/validator.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import Messages from 'ember-validator/messages';
 import Errors from 'ember-validator/errors';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const {
   Object: EmberObject,
@@ -59,7 +58,7 @@ export default EmberObject.extend({
     message = message || 'Invalid';
 
     // Handle the `Ember.Handlebars.SafeString()` and the `Ember.String.htmlSafe()` cases.
-    if (isHTMLSafe(message)) {
+    if (Ember.String.isHTMLSafe(message)) {
       message = message.toString();
     }
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-getowner-polyfill": "^1.0.0",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1"
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Latest release places the polyfill in the “native” location, instead of needing to import the function.

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5